### PR TITLE
iOS 9 Startup crash fix. It requires rootViewController for any UIWindow

### DIFF
--- a/RRFPSBar/RRFPSBar.m
+++ b/RRFPSBar/RRFPSBar.m
@@ -138,6 +138,8 @@
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         _sharedInstance = [[RRFPSBar alloc] init];
+        if([[UIDevice currentDevice].systemVersion floatValue] >= 9.0)
+            _sharedInstance.rootViewController = [UIViewController new]; // iOS 9 requires rootViewController for any window
     });
     return _sharedInstance;
 }


### PR DESCRIPTION
Due to this issue https://github.com/RolandasRazma/RRFPSBar/issues/10 using of  RRFPSBar led to crash on devices with iOS 9. This OS version requires rootViewController for any UIWindow. This code fixes this issue 