### PR TITLE
prevent self to be key window

### DIFF
--- a/RRFPSBar/RRFPSBar.m
+++ b/RRFPSBar/RRFPSBar.m
@@ -154,6 +154,12 @@
     [_displayLink setPaused:YES];
 }
 
+- (void)becomeKeyWindow{//prevent self to be key window
+    self.hidden = YES;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        self.hidden = NO;
+    });
+}
 
 - (void)displayLinkTick {
     


### PR DESCRIPTION
I find that `RRFPSBar` will become `keyWindow` when `UIActionSheet` or `UIAlertView` show, which cause bug in my App. 

Maybe my code is not good enough( I cannot find a better solution to avoid the window to become key ), but it effective.

Hope you have a better solution~
